### PR TITLE
Add markdown support with Redcarpet & Pygments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,10 @@ gem "httparty", "~> 0.13.3"
 gem "party_foul", "~> 1.5.5"
 gem "airbrake", "~> 4.1.0"
 
+# Markdown support.
+gem "redcarpet", "~> 3.2.1"
+gem "pygments.rb", "~> 0.6.0"
+
 # Styling. Thanks Thoughtbot!
 gem "bitters", "~> 0.10.1"
 gem "bourbon", "~> 3.2.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,10 @@ GEM
     party_foul (1.5.5)
       octokit (~> 3.1)
     pg (0.17.1)
+    posix-spawn (0.3.9)
+    pygments.rb (0.6.0)
+      posix-spawn (~> 0.3.6)
+      yajl-ruby (~> 1.1.0)
     quiet_assets (1.0.3)
       railties (>= 3.1, < 5.0)
     rack (1.5.2)
@@ -203,6 +207,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
+    redcarpet (3.2.1)
     rspec-core (3.1.4)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.1)
@@ -253,6 +258,7 @@ GEM
       json (>= 1.8.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    yajl-ruby (1.1.0)
 
 PLATFORMS
   ruby
@@ -277,9 +283,11 @@ DEPENDENCIES
   omniauth-github (~> 1.1.2)
   party_foul (~> 1.5.5)
   pg (~> 0.17.1)
+  pygments.rb (~> 0.6.0)
   quiet_assets (~> 1.0.3)
   rails (= 4.1.6)
   rails_12factor (~> 0.0.3)
+  redcarpet (~> 3.2.1)
   rspec-rails (~> 3.1.0)
   sass-rails (~> 4.0.3)
   shoulda-matchers

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,3 +11,4 @@
 @import "judges";
 @import "solutions";
 @import "github"; // GitHubs syntax theme.
+@import "pygments";

--- a/app/assets/stylesheets/pygments.css.scss.erb
+++ b/app/assets/stylesheets/pygments.css.scss.erb
@@ -1,0 +1,3 @@
+.highlight{
+  <%= Pygments.css(style: "colorful") %>
+}

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -18,11 +18,6 @@ module LayoutHelper
     date.strftime(format)
   end
 
-  # No op. for now.
-  def markdown(text)
-    simple_format(text)
-  end
-
   def solution_source(solution)
     content_tag :code, data: {language: solution.highlight_lang} do
       solution.source_code_content

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,26 @@
+module MarkdownHelper
+  class HTMLwithPygments < Redcarpet::Render::HTML
+    def block_code(code, language)
+      sha = Digest::SHA1.hexdigest(code)
+      Rails.cache.fetch ["code", language, sha].join('-') do
+        Pygments.highlight(code, lexer: language)
+      end
+    end
+  end
+
+  def markdown(text)
+    renderer = HTMLwithPygments.new(hard_wrap: true, filter_html: true, no_styles: true)
+    options = {
+      autolink: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      lax_html_blocks: true,
+      strikethrough: true,
+      superscript: true,
+      tables: true,
+      disable_indented_code_blocks: true,
+      highlight: true,
+    }
+    Redcarpet::Markdown.new(renderer, options).render(text).html_safe
+  end
+end


### PR DESCRIPTION
Solution explanations will now have Markdown support, this should allow the
users to format their explanations better and add some colored code-snippets
if needed.

Closes #19
